### PR TITLE
60FPS/DNAS Patch Implementation

### DIFF
--- a/pcsx2-winrt/pcsx2-winrt.vcxproj
+++ b/pcsx2-winrt/pcsx2-winrt.vcxproj
@@ -208,6 +208,12 @@
     <None Include="resources\cheats_ni.zip">
       <DeploymentContent>true</DeploymentContent>
     </None>
+    <None Include="resources\cheats_60.zip">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="resources\cheats_dnas.zip">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\LockScreenLogo.scale-200.png" />

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1241,6 +1241,10 @@ struct Pcsx2Config
 		EnablePINE : 1, // enables inter-process communication
 		EnableWideScreenPatches : 1,
 		EnableNoInterlacingPatches : 1,
+#ifdef WINRT_XBOX
+		Enable60FPSPatches : 1,
+		EnableDNASPatches : 1,
+#endif		
 		// TODO - Vaser - where are these settings exposed in the Qt UI?
 		EnableRecordingTools : 1,
 		EnableGameFixes : 1, // enables automatic game fixes
@@ -1335,6 +1339,10 @@ namespace EmuFolders
 	extern std::string Cheats;
 	extern std::string CheatsWS;
 	extern std::string CheatsNI;
+#ifdef WINRT_XBOX
+	extern std::string Cheats60;
+	extern std::string CheatsDNAS;
+#endif	
 	extern std::string Resources;
 	extern std::string Cache;
 	extern std::string Covers;

--- a/pcsx2/Host.cpp
+++ b/pcsx2/Host.cpp
@@ -254,6 +254,10 @@ void Host::Internal::UpdateEmuFolders()
 	const std::string old_cheats_directory(EmuFolders::Cheats);
 	const std::string old_cheats_ws_directory(EmuFolders::CheatsWS);
 	const std::string old_cheats_ni_directory(EmuFolders::CheatsNI);
+#ifdef WINRT_XBOX
+	const std::string old_cheats_60_directory(EmuFolders::Cheats60);
+	const std::string old_cheats_dnas_directory(EmuFolders::CheatsDNAS);
+#endif	
 	const std::string old_memcards_directory(EmuFolders::MemoryCards);
 	const std::string old_textures_directory(EmuFolders::Textures);
 	const std::string old_videos_directory(EmuFolders::Videos);
@@ -263,8 +267,14 @@ void Host::Internal::UpdateEmuFolders()
 
 	if (VMManager::HasValidVM())
 	{
+#ifdef WINRT_XBOX
+		if (EmuFolders::Cheats != old_cheats_directory || EmuFolders::CheatsWS != old_cheats_ws_directory ||
+			EmuFolders::CheatsNI != old_cheats_ni_directory || EmuFolders::Cheats60 != old_cheats_60_directory ||
+			EmuFolders::CheatsDNAS != old_cheats_dnas_directory)
+#else
 		if (EmuFolders::Cheats != old_cheats_directory || EmuFolders::CheatsWS != old_cheats_ws_directory ||
 			EmuFolders::CheatsNI != old_cheats_ni_directory)
+#endif
 		{
 			VMManager::ReloadPatches(true, true);
 		}

--- a/pcsx2/ImGui/FullscreenUI.cpp
+++ b/pcsx2/ImGui/FullscreenUI.cpp
@@ -2882,9 +2882,24 @@ void FullscreenUI::DrawEmulationSettingsPage()
 	DrawToggleSetting(bsi, "Enable Instant VU1",
 		"Reduces timeslicing between VU1 and EE recompilers, effectively running VU1 at an infinite clock speed.", "EmuCore/Speedhacks",
 		"vu1Instant", true);
+#ifndef WINRT_XBOX
 	DrawToggleSetting(bsi, "Enable Cheats", "Enables loading cheats from pnach files.", "EmuCore", "EnableCheats", false);
+#endif
 	DrawToggleSetting(bsi, "Enable Host Filesystem", "Enables access to files from the host: namespace in the virtual machine.", "EmuCore",
 		"HostFs", false);
+
+#ifdef WINRT_XBOX	
+	MenuHeading("Patches");
+	DrawToggleSetting(bsi, "Enable Cheats", "Enables loading cheats from pnach files.", "EmuCore", "EnableCheats", false);
+	DrawToggleSetting(bsi, "Enable Widescreen Patches", "Enables loading widescreen patches from pnach files.", "EmuCore",
+		"EnableWideScreenPatches", false);
+	DrawToggleSetting(bsi, "Enable No-Interlacing Patches", "Enables loading no-interlacing patches from pnach files.", "EmuCore",
+		"EnableNoInterlacingPatches", false);
+	DrawToggleSetting(bsi, "Enable 60FPS Patches", "Enables loading 60fps patches from pnach files.", "EmuCore",
+		"Enable60FPSPatches", false);
+	DrawToggleSetting(bsi, "Enable DNAS Patches", "Enables loading DNAS patches from pnach files.", "EmuCore",
+		"EnableDNASPatches", false);
+#endif
 
 	if (IsEditingGameSettings(bsi))
 	{
@@ -3115,10 +3130,12 @@ void FullscreenUI::DrawGraphicsSettingsPage()
 		100, 10, 300, "%d%%");
 	DrawIntRectSetting(bsi, "Crop", "Crops the image, while respecting aspect ratio.", "EmuCore/GS", "CropLeft", 0, "CropTop", 0,
 		"CropRight", 0, "CropBottom", 0, 0, 720, 1, "%dpx");
+#ifndef WINRT_XBOX
 	DrawToggleSetting(bsi, "Enable Widescreen Patches", "Enables loading widescreen patches from pnach files.", "EmuCore",
 		"EnableWideScreenPatches", false);
 	DrawToggleSetting(bsi, "Enable No-Interlacing Patches", "Enables loading no-interlacing patches from pnach files.", "EmuCore",
 		"EnableNoInterlacingPatches", false);
+#endif
 	DrawIntListSetting(bsi, "Bilinear Upscaling", "Smooths out the image when upscaling the console to the screen.", "EmuCore/GS",
 		"linear_present_mode", static_cast<int>(GSPostBilinearMode::BilinearSharp), s_bilinear_present_options,
 		std::size(s_bilinear_present_options));

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -96,6 +96,10 @@ namespace EmuFolders
 	std::string Cheats;
 	std::string CheatsWS;
 	std::string CheatsNI;
+#ifdef WINRT_XBOX
+	std::string Cheats60;
+	std::string CheatsDNAS;
+#endif
 	std::string Resources;
 	std::string Cache;
 	std::string Covers;
@@ -1337,6 +1341,10 @@ void Pcsx2Config::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapBitBool(EnablePINE);
 	SettingsWrapBitBool(EnableWideScreenPatches);
 	SettingsWrapBitBool(EnableNoInterlacingPatches);
+#ifdef WINRT_XBOX
+	SettingsWrapBitBool(Enable60FPSPatches);
+	SettingsWrapBitBool(EnableDNASPatches);
+#endif
 	SettingsWrapBitBool(EnableRecordingTools);
 	SettingsWrapBitBool(EnableGameFixes);
 	SettingsWrapBitBool(SaveStateOnShutdown);
@@ -1482,6 +1490,10 @@ void EmuFolders::SetDefaults(SettingsInterface& si)
 	si.SetStringValue("Folders", "Cheats", "cheats");
 	si.SetStringValue("Folders", "CheatsWS", "cheats_ws");
 	si.SetStringValue("Folders", "CheatsNI", "cheats_ni");
+#ifdef WINRT_XBOX
+	si.SetStringValue("Folders", "Cheats60", "cheats_60");
+	si.SetStringValue("Folders", "CheatsDNAS", "cheats_dnas");
+#endif	
 	si.SetStringValue("Folders", "Cache", "cache");
 	si.SetStringValue("Folders", "Textures", "textures");
 	si.SetStringValue("Folders", "InputProfiles", "inputprofiles");
@@ -1506,6 +1518,10 @@ void EmuFolders::LoadConfig(SettingsInterface& si)
 	Cheats = LoadPathFromSettings(si, DataRoot, "Cheats", "cheats");
 	CheatsWS = LoadPathFromSettings(si, DataRoot, "CheatsWS", "cheats_ws");
 	CheatsNI = LoadPathFromSettings(si, DataRoot, "CheatsNI", "cheats_ni");
+#ifdef WINRT_XBOX
+	Cheats60 = LoadPathFromSettings(si, DataRoot, "Cheats60", "cheats_60");
+	CheatsDNAS = LoadPathFromSettings(si, DataRoot, "CheatsDNAS", "cheats_dnas");
+#endif
 	Covers = LoadPathFromSettings(si, DataRoot, "Covers", "covers");
 	GameSettings = LoadPathFromSettings(si, DataRoot, "GameSettings", "gamesettings");
 	Cache = LoadPathFromSettings(si, DataRoot, "Cache", "cache");
@@ -1521,6 +1537,10 @@ void EmuFolders::LoadConfig(SettingsInterface& si)
 	Console.WriteLn("Cheats Directory: %s", Cheats.c_str());
 	Console.WriteLn("CheatsWS Directory: %s", CheatsWS.c_str());
 	Console.WriteLn("CheatsNI Directory: %s", CheatsNI.c_str());
+#ifdef WINRT_XBOX
+	Console.WriteLn("Cheats60 Directory: %s", Cheats60.c_str());
+	Console.WriteLn("CheatsDNAS Directory: %s", CheatsDNAS.c_str());
+#endif	
 	Console.WriteLn("Covers Directory: %s", Covers.c_str());
 	Console.WriteLn("Game Settings Directory: %s", GameSettings.c_str());
 	Console.WriteLn("Cache Directory: %s", Cache.c_str());
@@ -1540,6 +1560,10 @@ bool EmuFolders::EnsureFoldersExist()
 	result = FileSystem::CreateDirectoryPath(Cheats.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(CheatsWS.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(CheatsNI.c_str(), false) && result;
+#ifdef WINRT_XBOX
+	result = FileSystem::CreateDirectoryPath(Cheats60.c_str(), false) && result;
+	result = FileSystem::CreateDirectoryPath(CheatsDNAS.c_str(), false) && result;
+#endif
 	result = FileSystem::CreateDirectoryPath(Covers.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(GameSettings.c_str(), false) && result;
 	result = FileSystem::CreateDirectoryPath(Cache.c_str(), false) && result;


### PR DESCRIPTION
### Description of Changes
- Enabled using 60FPS and DNAS Patches in the Frontend, both in Qt and Big Picture.

- Implement reading pnach files from either cheats_60/cheats_dnas folders or the respective zip files.

- Moved all "Enable Patch" options to the Emulation Settings under a "Patches" header for ease of use in both Qt and Big Picture.

### Rationale behind Changes
The changes above were made for ease of use, having both 60FPS and DNAS bypass patches available in PCSX2 makes things more straightforward for the end user as opposed to them being read as standard cheats files.
