### PR TITLE
WINRT/UWP: Misc. Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ oprofile_data/
 CMakeSettings.json
 /ci-artifacts/
 /out/
+
+# WINRT/UWP Files
 /pcsx2-winrt/resources/cheats_ws.zip
 /pcsx2-winrt/resources/cheats_ni.zip
 /pcsx2-winrt/resources/cheats_60.zip
@@ -114,3 +116,7 @@ CMakeSettings.json
 /Search Results.txt
 /findstr_CLI.bat
 /findstr_CLI(1).bat
+
+# GitHub Desktop Stupidity
+PCSX2_qt.sln
+/pcsx2-winrt/pcsx2-winrt.vcxproj.filters

--- a/pcsx2-winrt/pcsx2-winrt.vcxproj
+++ b/pcsx2-winrt/pcsx2-winrt.vcxproj
@@ -83,13 +83,12 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>PrecompiledHeader.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pcsx2.pch</PrecompiledHeaderOutputFile>
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;ENABLE_RAINTEGRATION;ENABLE_ACHIEVEMENTS;DIRECTINPUT_VERSION=0x0800;PCSX2_CORE;WINRT_XBOX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;LZMA_API_STATIC;BUILD_DX=1;ENABLE_RAINTEGRATION;ENABLE_ACHIEVEMENTS;DIRECTINPUT_VERSION=0x0800;PCSX2_CORE;WINRT_XBOX;UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Debug))">PCSX2_DEBUG;PCSX2_DEVBUILD;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Devel))">PCSX2_DEVEL;PCSX2_DEVBUILD;NDEBUG;_SECURE_SCL_=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(Release))">NDEBUG;_SECURE_SCL_=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="!$(Configuration.Contains(AVX2))">_M_SSE=0x401;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(Configuration.Contains(AVX2))">_M_SSE=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet Condition="!$(Configuration.Contains(AVX2)) Or $(Configuration.Contains(Clang))">AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="$(Configuration.Contains(AVX2)) And !$(Configuration.Contains(Clang))">AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
       <AdditionalOptions Condition="$(Configuration.Contains(Clang)) And !$(Configuration.Contains(AVX2))"> -march=nehalem %(AdditionalOptions)</AdditionalOptions>
@@ -162,12 +161,12 @@
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;ENABLE_ACHIEVEMENTS;UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)' == 'Release' or '$(Configuration)' == 'Release AVX2'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;ENABLE_ACHIEVEMENTS;UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -818,7 +818,7 @@ bool GameList::RescanPath(const std::string& path)
 
 std::string GameList::GetPlayedTimeFile()
 {
-	return Path::Combine(EmuFolders::Settings, "playtime.dat");
+	return Path::Combine(EmuFolders::Logs, "playtime.dat");
 }
 
 bool GameList::ParsePlayedTimeLine(char* line, std::string& serial, PlayedTimeEntry& entry)


### PR DESCRIPTION
### Description of Changes
- Update the .gitignore file so GitHub Desktop stops screwing with these two files for no reason. Also adds a comment to make the file more organized.
- Cleans up a bit of redundant code in `pcsx2_winrt.vcxproj` file, these PreprocessorDefinitions only need to appear once and the code will still build and work just fine.
- Changes the `playtime.dat` file directory from the `inis` folder to the `logs` folder. This way we have one less file that can't be loaded from an external USB, leaving only the main .ini file stuck in the LocalState folder.

### Rationale behind Changes
- Cleaner code.
- A near-complete USB setup is now possible.

### Suggested Testing Steps
- Make sure the code builds just fine.
- Make sure the game session timer still works as it should.
